### PR TITLE
Add BackofficeAuth middleware and register alias

### DIFF
--- a/app/Http/Middleware/BackofficeAuth.php
+++ b/app/Http/Middleware/BackofficeAuth.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class BackofficeAuth extends Middleware
+{
+    protected function redirectTo(Request $request): ?string
+    {
+        if (!$request->expectsJson()) {
+            return route('backoffice.login');
+        }
+
+        return null;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,7 @@ use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use App\Http\Middleware\Role;
+use App\Http\Middleware\BackofficeAuth;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -16,6 +17,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([
             'role' => Role::class,
+            'auth' => BackofficeAuth::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {


### PR DESCRIPTION
Introduced BackofficeAuth middleware to handle authentication redirection for backoffice routes. Registered the middleware with the 'auth' alias in bootstrap/app.php to replace or extend default authentication behavior.